### PR TITLE
Upgrade/sequelize

### DIFF
--- a/lib/sequelizeSchema.js
+++ b/lib/sequelizeSchema.js
@@ -80,7 +80,7 @@ class JsonSchema {
 	selectAttributes() {
 		let attributes = this.options.selectAttributes ?
 			this.options.selectAttributes(this.model) :
-			Object.keys(this.model.attributes);
+			Object.keys(this.model.rawAttributes);
 
 		attributes = attributes.concat(this.selectAssociations());
 
@@ -206,7 +206,7 @@ class JsonSchema {
 		});
 
 		if (this.getDbType(modelAttr) === 'ENUM') {
-			property.enum = this.model.attributes[modelAttr].type.values;
+			property.enum = this.model.rawAttributes[modelAttr].type.values;
 		}
 
 		return [jsonKey, property];
@@ -279,10 +279,10 @@ class JsonSchema {
 			return 'STRING';
 		}
 
-		if (!this.model.attributes[modelAttr]) {
+		if (!this.model.rawAttributes[modelAttr]) {
 			throw new Error(`Unknown model attribute ${this.model.name}.${modelAttr}`);
 		}
-		const dbType = this.model.attributes[modelAttr].type.key;
+		const dbType = this.model.rawAttributes[modelAttr].type.key;
 
 		return dbType;
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-to-json-schema",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Flexible json-schema generator from sequelize models",
   "main": "lib/index.js",
   "scripts": {
@@ -45,6 +45,6 @@
     "mocha": "^5.1.0"
   },
   "peerDependencies": {
-    "sequelize": "^3.31.2"
+    "sequelize": "^6.19.2"
   }
 }

--- a/test/mockModel.js
+++ b/test/mockModel.js
@@ -7,13 +7,13 @@ function modelFactory(name, attributes) {
 		associate,
 		name,
 		tableName: name,
-		attributes: {},
+		rawAttributes: {},
 		associations: {},
 	};
 
 	_.forEach(attributes, (value, attr) => {
 		const attribute = _.isString(value) ? { key: value } : value;
-		model.attributes[attr] = { type: attribute };
+		model.rawAttributes[attr] = { type: attribute };
 	});
 
 	models[name] = model;

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -16,7 +16,7 @@ function selectAttributes(model) {
 		return ['full_name', 'address', 'profile', 'status', 'name'];
 	}
 
-	return Object.keys(model.attributes);
+	return Object.keys(model.rawAttributes);
 }
 
 function jsonAttributeMapper(model, name) {


### PR DESCRIPTION
This upgrades the sequelize peer dependancy and also takes into account breaking changes from Sequelize v4->v5 re rawAttributes. 

https://sequelize.org/v5/manual/upgrade-to-v5.html
> Attributes: Model.attributes now removed, use Model.rawAttributes. [#5320](https://github.com/sequelize/sequelize/issues/5320)

